### PR TITLE
changed coin_ID url

### DIFF
--- a/cryptocmd/utils.py
+++ b/cryptocmd/utils.py
@@ -35,7 +35,7 @@ def get_coin_id(coin_code):
     """
 
     try:
-        url = 'https://api.coinmarketcap.com/v1/ticker/'
+        url = 'https://api.coinmarketcap.com/v1/ticker/?limit=0'
 
         json_resp = get_url_data(url).json()
 


### PR DESCRIPTION
**Fixes issue:** 
get all IDs rather than only top 100; enables user to download data for all crypto-assets on coinmarketcap.com, rather than just top 100

**Changes:**
url from which to pull ticker symbols adds '?limit=0' parameter
