### PR TITLE
allow to download price data in EUR and other fiat currencies

### DIFF
--- a/cryptocmd/core.py
+++ b/cryptocmd/core.py
@@ -31,6 +31,7 @@ class CmcScraper(object):
         end_date=None,
         all_time=False,
         order_ascending=False,
+        fiat="USD"
     ):
         """
         :param coin_code: coin code of cryptocurrency e.g. btc
@@ -38,6 +39,7 @@ class CmcScraper(object):
         :param end_date: date to which scrape the data (in the format of dd-mm-yyyy)
         :param all_time: 'True' if need data of all time for respective cryptocurrency
         :param order_ascending: data ordered by 'Date' in ascending order (i.e. oldest first).
+        :param fiat: fiat code eg. USD, EUR
 
         """
 
@@ -46,6 +48,7 @@ class CmcScraper(object):
         self.end_date = end_date
         self.all_time = bool(all_time)
         self.order_ascending = order_ascending
+        self.fiat=fiat
         self.headers = ["Date", "Open", "High", "Low", "Close", "Volume", "Market Cap"]
         self.rows = []
 
@@ -80,7 +83,7 @@ class CmcScraper(object):
         if self.all_time:
             self.start_date, self.end_date = None, None
 
-        coin_data = download_coin_data(self.coin_code, self.start_date, self.end_date)
+        coin_data = download_coin_data(self.coin_code, self.start_date, self.end_date,self.fiat)
 
         for _row in coin_data["data"]["quotes"]:
 

--- a/cryptocmd/core.py
+++ b/cryptocmd/core.py
@@ -31,7 +31,7 @@ class CmcScraper(object):
         end_date=None,
         all_time=False,
         order_ascending=False,
-        fiat="USD"
+        fiat="USD",
     ):
         """
         :param coin_code: coin code of cryptocurrency e.g. btc
@@ -48,7 +48,7 @@ class CmcScraper(object):
         self.end_date = end_date
         self.all_time = bool(all_time)
         self.order_ascending = order_ascending
-        self.fiat=fiat
+        self.fiat = fiat
         self.headers = ["Date", "Open", "High", "Low", "Close", "Volume", "Market Cap"]
         self.rows = []
 
@@ -83,7 +83,9 @@ class CmcScraper(object):
         if self.all_time:
             self.start_date, self.end_date = None, None
 
-        coin_data = download_coin_data(self.coin_code, self.start_date, self.end_date,self.fiat)
+        coin_data = download_coin_data(
+            self.coin_code, self.start_date, self.end_date, self.fiat
+        )
 
         for _row in coin_data["data"]["quotes"]:
 
@@ -190,7 +192,7 @@ class CmcScraper(object):
         if csv_name is None:
             # Make name fo file in format of {coin_code}_{fiat}_{start_date}_{end_date}.csv
             csv_name = "{0}_{1}_{2}_{3}.csv".format(
-                self.coin_code, self.fiat,self.start_date, self.end_date
+                self.coin_code, self.fiat, self.start_date, self.end_date
             )
 
         if not csv_name.endswith(".csv"):
@@ -227,8 +229,10 @@ class CmcScraper(object):
             path = os.getcwd()
 
         if name is None:
-            # Make name of file in format: {coin_code}_{start_date}_{end_date}.csv
-            name = "{0}_{1}_{2}".format(self.coin_code, self.start_date, self.end_date)
+            # Make name of file in format: {coin_code}_{fiat}_{start_date}_{end_date}.csv
+            name = "{0}_{1}-{2}_{3}".format(
+                self.coin_code, self.fiat, self.start_date, self.end_date
+            )
 
         if not name.endswith(".{}".format(format)):
             name += ".{}".format(format)

--- a/cryptocmd/core.py
+++ b/cryptocmd/core.py
@@ -189,8 +189,8 @@ class CmcScraper(object):
 
         if csv_name is None:
             # Make name fo file in format of {coin_code}_{start_date}_{end_date}.csv
-            csv_name = "{0}_{1}_{2}.csv".format(
-                self.coin_code, self.start_date, self.end_date
+            csv_name = "{0}_{1}_{2}_{3}.csv".format(
+                self.coin_code, self.fiat,self.start_date, self.end_date
             )
 
         if not csv_name.endswith(".csv"):

--- a/cryptocmd/core.py
+++ b/cryptocmd/core.py
@@ -188,7 +188,7 @@ class CmcScraper(object):
             csv_path = os.getcwd()
 
         if csv_name is None:
-            # Make name fo file in format of {coin_code}_{start_date}_{end_date}.csv
+            # Make name fo file in format of {coin_code}_{fiat}_{start_date}_{end_date}.csv
             csv_name = "{0}_{1}_{2}_{3}.csv".format(
                 self.coin_code, self.fiat,self.start_date, self.end_date
             )

--- a/cryptocmd/utils.py
+++ b/cryptocmd/utils.py
@@ -57,13 +57,14 @@ def get_coin_id(coin_code):
             print("Error message:", e)
 
 
-def download_coin_data(coin_code, start_date, end_date):
+def download_coin_data(coin_code, start_date, end_date,fiat):
     """
     Download HTML price history for the specified cryptocurrency and time range from CoinMarketCap.
 
     :param coin_code: coin code of a cryptocurrency e.g. btc
     :param start_date: date since when to scrape data (in the format of dd-mm-yyyy)
     :param end_date: date to which scrape the data (in the format of dd-mm-yyyy)
+    :param fiat: fiat code eg. USD, EUR
     :return: returns html of the webpage having historical data of cryptocurrency for certain duration
     """
 
@@ -93,8 +94,8 @@ def download_coin_data(coin_code, start_date, end_date):
         .timestamp()
     )
 
-    api_url = "https://web-api.coinmarketcap.com/v1/cryptocurrency/ohlcv/historical?convert=USD&slug={}&time_end={}&time_start={}".format(
-        coin_id, end_date_timestamp, start_date_timestamp
+    api_url = "https://web-api.coinmarketcap.com/v1/cryptocurrency/ohlcv/historical?convert={}&slug={}&time_end={}&time_start={}".format(
+        fiat,coin_id, end_date_timestamp, start_date_timestamp
     )
 
     try:


### PR DESCRIPTION
**Fixes issue:** 
Fixes issue of being able to download price data only in USD.

**Changes:**
* `cryptocmd.utils.download_coin_data` has new argument `fiat`, a string code to specify that price data is returned in the desired fiat currency eg. USD, EUR
* `cryptocmd.core.CmcScraper` has new attribute `fiat`. Default is `USD` but can now be changed during initialization.
