### PR TITLE
id_number parameter added

### DIFF
--- a/cryptocmd/core.py
+++ b/cryptocmd/core.py
@@ -32,6 +32,7 @@ class CmcScraper(object):
         all_time=False,
         order_ascending=False,
         fiat="USD",
+        id_number = None,
     ):
         """
         :param coin_code: coin code of cryptocurrency e.g. btc
@@ -40,6 +41,7 @@ class CmcScraper(object):
         :param all_time: 'True' if need data of all time for respective cryptocurrency
         :param order_ascending: data ordered by 'Date' in ascending order (i.e. oldest first).
         :param fiat: fiat code eg. USD, EUR
+        :param id_number: id number for the a cryptocurrency on the coinmarketcap.com. Will override coin_code
 
         """
 
@@ -51,6 +53,7 @@ class CmcScraper(object):
         self.fiat = fiat
         self.headers = ["Date", "Open", "High", "Low", "Close", "Volume", "Market Cap"]
         self.rows = []
+        self.id_number = id_number
 
         # enable all_time download if start_time or end_time is not given
         if not (self.start_date and self.end_date):
@@ -84,7 +87,7 @@ class CmcScraper(object):
             self.start_date, self.end_date = None, None
 
         coin_data = download_coin_data(
-            self.coin_code, self.start_date, self.end_date, self.fiat
+            self.coin_code, self.start_date, self.end_date, self.fiat, self.id_number
         )
 
         for _row in coin_data["data"]["quotes"]:

--- a/cryptocmd/utils.py
+++ b/cryptocmd/utils.py
@@ -57,7 +57,7 @@ def get_coin_id(coin_code):
             print("Error message:", e)
 
 
-def download_coin_data(coin_code, start_date, end_date, fiat):
+def download_coin_data(coin_code, start_date, end_date, fiat, id_number=None):
     """
     Download HTML price history for the specified cryptocurrency and time range from CoinMarketCap.
 
@@ -65,6 +65,7 @@ def download_coin_data(coin_code, start_date, end_date, fiat):
     :param start_date: date since when to scrape data (in the format of dd-mm-yyyy)
     :param end_date: date to which scrape the data (in the format of dd-mm-yyyy)
     :param fiat: fiat code eg. USD, EUR
+    :param id_number: id number for the token on coinmarketcap. Will override coin_code.
     :return: returns html of the webpage having historical data of cryptocurrency for certain duration
     """
 
@@ -76,7 +77,8 @@ def download_coin_data(coin_code, start_date, end_date, fiat):
         yesterday = datetime.date.today() - datetime.timedelta(1)
         end_date = yesterday.strftime("%d-%m-%Y")
 
-    coin_id = get_coin_id(coin_code)
+    if not id_number:
+        coin_id = get_coin_id(coin_code)
 
     # convert the dates to timestamp for the url
     start_date_timestamp = int(
@@ -94,9 +96,14 @@ def download_coin_data(coin_code, start_date, end_date, fiat):
         .timestamp()
     )
 
-    api_url = "https://web-api.coinmarketcap.com/v1/cryptocurrency/ohlcv/historical?convert={}&slug={}&time_end={}&time_start={}".format(
-        fiat, coin_id, end_date_timestamp, start_date_timestamp
-    )
+    if id_number:
+        api_url = "https://web-api.coinmarketcap.com/v1/cryptocurrency/ohlcv/historical?convert={}&id={}&time_end={}&time_start={}".format(
+            fiat, id_number, end_date_timestamp, start_date_timestamp
+        )
+    else:
+        api_url = "https://web-api.coinmarketcap.com/v1/cryptocurrency/ohlcv/historical?convert={}&slug={}&time_end={}&time_start={}".format(
+            fiat, coin_id, end_date_timestamp, start_date_timestamp
+        )
 
     try:
         json_data = get_url_data(api_url).json()


### PR DESCRIPTION
**Fixes issue:** #41 #21 

**Changes:**
I added the `id_number` parameter to the `CmcScraper` class. It overrides `coin_code` to avoid mistakes with repeated symbols.
The `id_number` can be retrieved from https://web-api.coinmarketcap.com/v1/cryptocurrency/map?symbol={SYMBOL}.
The URL above will give all tokens with the `symbol` provided.
