### PR TITLE
Allow specifying coin name in case coins share code and first one in the list is not correct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
       - name: Install package
         run: python setup.py install
       - name: Run test script
-        run: python examples/get_csv.py
+        run: python examples/get_csv.py && python examples/get_by_coin_name.py

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,28 @@ To get all time historical data of a cryptocurrency
     # Pandas dataFrame for the same data
     df = scraper.get_dataframe()
 
+To get data of a cryptocurrency which have same coin code as others
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code:: python
+
+    from cryptocmd import CmcScraper
+
+    # initialise scraper with coin name as well
+    scraper = CmcScraper(coin_code="sol", coin_name="solana")
+
+    # get raw data as list of list
+    headers, data = scraper.get_data()
+
+    # get data in a json format
+    solana_json_data = scraper.get_data("json")
+
+    # export the data as csv file, you can also pass optional `name` parameter
+    scraper.export("csv", name="solana_all_time")
+
+    # Pandas dataFrame for the same data
+    df = scraper.get_dataframe()
+
 To get data of a cryptocurrency for some days
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/cryptocmd/core.py
+++ b/cryptocmd/core.py
@@ -32,6 +32,7 @@ class CmcScraper(object):
         all_time=False,
         order_ascending=False,
         fiat="USD",
+        coin_name=None,
     ):
         """
         :param coin_code: coin code of cryptocurrency e.g. btc
@@ -40,7 +41,7 @@ class CmcScraper(object):
         :param all_time: 'True' if need data of all time for respective cryptocurrency
         :param order_ascending: data ordered by 'Date' in ascending order (i.e. oldest first).
         :param fiat: fiat code eg. USD, EUR
-
+        :param coin_name: coin name in case of many coins with same code e.g. sol -> solana, solcoin
         """
 
         self.coin_code = coin_code
@@ -49,6 +50,7 @@ class CmcScraper(object):
         self.all_time = bool(all_time)
         self.order_ascending = order_ascending
         self.fiat = fiat
+        self.coin_name = coin_name
         self.headers = ["Date", "Open", "High", "Low", "Close", "Volume", "Market Cap"]
         self.rows = []
 
@@ -84,7 +86,7 @@ class CmcScraper(object):
             self.start_date, self.end_date = None, None
 
         coin_data = download_coin_data(
-            self.coin_code, self.start_date, self.end_date, self.fiat
+            self.coin_code, self.start_date, self.end_date, self.fiat, self.coin_name
         )
 
         for _row in coin_data["data"]["quotes"]:

--- a/cryptocmd/utils.py
+++ b/cryptocmd/utils.py
@@ -26,10 +26,11 @@ def get_url_data(url):
         raise e
 
 
-def get_coin_id(coin_code):
+def get_coin_id(coin_code, coin_name):
     """
     This method fetches the name(id) of currency from the given code
     :param coin_code: coin code of a cryptocurrency e.g. btc
+    :param coin_name: coin name in case of many coins with same code e.g. sol -> solana, solcoin
     :return: coin-id for the a cryptocurrency on the coinmarketcap.com
     """
 
@@ -41,7 +42,10 @@ def get_coin_id(coin_code):
         json_data = get_url_data(api_url).json()
         error_code = json_data["status"]["error_code"]
         if error_code == 0:
-            return json_data["data"][0]["slug"]
+            if coin_name is None:
+                return json_data["data"][0]["slug"]
+
+            return [data["slug"] for data in json_data["data"] if data["name"].lower() == coin_name.lower()][0]
         if error_code == 400:
             raise InvalidCoinCode(
                 "'{}' coin code is unavailable on coinmarketcap.com".format(coin_code)
@@ -57,7 +61,7 @@ def get_coin_id(coin_code):
             print("Error message:", e)
 
 
-def download_coin_data(coin_code, start_date, end_date, fiat):
+def download_coin_data(coin_code, start_date, end_date, fiat, coin_name):
     """
     Download HTML price history for the specified cryptocurrency and time range from CoinMarketCap.
 
@@ -65,6 +69,7 @@ def download_coin_data(coin_code, start_date, end_date, fiat):
     :param start_date: date since when to scrape data (in the format of dd-mm-yyyy)
     :param end_date: date to which scrape the data (in the format of dd-mm-yyyy)
     :param fiat: fiat code eg. USD, EUR
+    :param coin_name: coin name in case of many coins with same code e.g. sol -> solana, solcoin
     :return: returns html of the webpage having historical data of cryptocurrency for certain duration
     """
 
@@ -76,7 +81,7 @@ def download_coin_data(coin_code, start_date, end_date, fiat):
         yesterday = datetime.date.today() - datetime.timedelta(1)
         end_date = yesterday.strftime("%d-%m-%Y")
 
-    coin_id = get_coin_id(coin_code)
+    coin_id = get_coin_id(coin_code, coin_name)
 
     # convert the dates to timestamp for the url
     start_date_timestamp = int(

--- a/examples/get_by_coin_name.py
+++ b/examples/get_by_coin_name.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from cryptocmd import CmcScraper
+
+# Initialise scraper with 'coin code' and 'coin name' of cryptocurrency
+# Need to pass both in case other coin(s) have same code
+# If time interval is not passed all time data will be scrapped
+scraper = CmcScraper(coin_code="sol", coin_name="solana")
+
+# You can pass name for the csv explicitly,
+# Else it will be named in format {coin_code}_{start_date}_{end_date}.csv
+scraper.export("csv", name="solana_all_time")


### PR DESCRIPTION
**Fixes issue:** #41 #21 

**Changes:**
You can input code_name along with coin_code, which when retrieving the data also checks for the coin name, not only coin_code
